### PR TITLE
Updates for latest rustc (2015-03-20)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: rust
 install:
   - sudo apt-get install python3
 script:
-  - cargo build --verbose && cargo test --verbose && rustdoc -L ./target/deps --test README.md
+  - cargo build --verbose && cargo test --verbose && rustdoc -L ./target/debug/deps --test README.md
 notifications:
     webhooks: http://huon.me:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ default = []
 # examples/failure.rs test
 compile_error = []
 
+[dependencies]
+tempdir = "0.3"
+
 [dev-dependencies.external_mixin]
 path = "external_mixin"
 version = "0"

--- a/external_mixin/src/lib.rs
+++ b/external_mixin/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(quote, plugin_registrar, rustc_private)]
-#![feature(path)]
 
 extern crate "external_mixin_umbrella" as emu;
 

--- a/rust_mixin/src/lib.rs
+++ b/rust_mixin/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(quote, plugin_registrar, rustc_private)]
-#![feature(path)]
 
 extern crate "external_mixin_umbrella" as emu;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(quote, plugin_registrar, rustc_private)]
-#![feature(tempdir, path, io, fs, process, std_misc)]
+#![feature(tempdir, std_misc)]
 
 extern crate syntax;
 extern crate rustc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl<F> MixinExpander<F>
             name: name,
             dir: dir,
             expander: expander
-        }), None))
+        }), None, false))
     }
     fn handle(&self, cx: &ExtCtxt, sp: codemap::Span,
               output: Output) -> Result<Vec<u8>, ()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
 #![feature(quote, plugin_registrar, rustc_private)]
-#![feature(tempdir, std_misc)]
+#![feature(std_misc)]
 
 extern crate syntax;
 extern crate rustc;
+extern crate tempdir;
 
 use std::collections::HashMap;
 use std::io;
 use std::io::prelude::*;
-use std::fs::{self, TempDir, File};
+use std::fs::{self, File};
 use std::path::{PathBuf, Path};
 use std::process;
 
@@ -17,6 +18,8 @@ use syntax::ext::base::{self, ExtCtxt, MacResult};
 use syntax::fold::Folder;
 use syntax::parse::{self, token};
 use rustc::plugin::Registry;
+
+use tempdir::TempDir;
 
 mod parser_any_macro;
 


### PR DESCRIPTION
Everything should be pretty straightforward here. I'm very oblivious to `ParserAnyMacro`'s particulars, but simply copying from the [latest macro_rules.rs](https://github.com/rust-lang/rust/blob/92dd995e1705a8c398a5266c8483e2519e494f47/src/libsyntax/ext/tt/macro_rules.rs) seemed to work.
